### PR TITLE
Make fields protected instead of private

### DIFF
--- a/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
+++ b/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
@@ -28,13 +28,13 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 public class ColorPreference extends DialogPreference {
-	private final String selectNoneButtonText;
-	private final Integer defaultColor;
-	private final String noneSelectedSummaryText;
-	private final CharSequence summaryText;
-	private final boolean showAlpha;
-	private final boolean showHex;
-	private View thumbnail;
+	protected final String selectNoneButtonText;
+	protected Integer defaultColor;
+	protected final String noneSelectedSummaryText;
+	protected final CharSequence summaryText;
+	protected final boolean showAlpha;
+	protected final boolean showHex;
+	protected View thumbnail;
 
 	public ColorPreference(Context context) {
 		this(context, null);


### PR DESCRIPTION
Hi Martin,

I couldn't extend `ColorPreference` properly without making these fields accessible by changing them from `private` to `protected`

Another user also mentioned this restriction in https://github.com/martin-stone/hsv-alpha-color-picker-android/issues/16

I also made `defaultColor` non-final so it is possible to change it programatically.

Would you consider integrating these changes in to your excellent library?

Thanks 
Jon
