### PR TITLE
Add option for hiding the swatchView

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Set to false to hide the alpha slider. (Default is visible.)
 
 Set to false to hide the hex value field. (Default is visible.)
 
+#### colorpicker_showPreview
+
+Set to false to hide the color preview field. (Default is visible.)
+
 ### ColorPickerView methods
 
 #### public int getColor()

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Set this to false to hide the alpha slider.
 
 Set this to false to hide the hex value field.
 
+#### colorpicker_showPreview
+
+Set this to false to hide the color preview field.
+
 **Note:** *colorpicker_defaultColor* was removed in version 2, in favour of *android:defaultValue*.
 If upgrading, just switch to using *android:defaultValue* instead.
 
@@ -158,6 +162,10 @@ Shows or hides the alpha slider.
 #### public void showHex(boolean showHex)
 
 Shows or hides the hex value field.
+
+#### public void showPreview(boolean showPreview)
+
+Shows or hides the color preview field.
 
 #### public void addColorObserver(ColorObserver observer)
 

--- a/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPickerView.java
+++ b/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPickerView.java
@@ -65,6 +65,7 @@ public class ColorPickerView extends FrameLayout {
 			TypedArray a = getContext().getTheme().obtainStyledAttributes(attrs, R.styleable.ColorPicker, 0, 0);
 			showAlpha(a.getBoolean(R.styleable.ColorPicker_colorpicker_showAlpha, true));
 			showHex(a.getBoolean(R.styleable.ColorPicker_colorpicker_showHex, true));
+			showPreview(a.getBoolean(R.styleable.ColorPicker_colorpicker_showPreview, true));
 		}
 	}
 
@@ -100,5 +101,9 @@ public class ColorPickerView extends FrameLayout {
 
 	public void showHex(boolean showHex) {
 		hexEdit.setVisibility(showHex ? View.VISIBLE : View.GONE);
+	}
+
+	public void showPreview(boolean showPreview) {
+		swatchView.setVisibility(showPreview ? View.VISIBLE : View.GONE);
 	}
 }

--- a/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
+++ b/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
@@ -141,6 +141,7 @@ public class ColorPreference extends DialogPreference {
 		picker.setColor(getPersistedInt(defaultColor == null ? Color.GRAY : defaultColor));
 		picker.showAlpha(showAlpha);
 		picker.showHex(showHex);
+		picker.showPreview(showPreview);
 		builder
 				.setTitle(null)
 				.setView(picker)

--- a/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
+++ b/colorpicker/src/main/java/com/rarepebble/colorpicker/ColorPreference.java
@@ -38,6 +38,7 @@ public class ColorPreference extends DialogPreference {
 	private final CharSequence summaryText;
 	private final boolean showAlpha;
 	private final boolean showHex;
+	private final boolean showPreview;
 	private View thumbnail;
 
 	public ColorPreference(Context context) {
@@ -53,12 +54,14 @@ public class ColorPreference extends DialogPreference {
 			noneSelectedSummaryText = a.getString(R.styleable.ColorPicker_colorpicker_noneSelectedSummaryText);
 			showAlpha = a.getBoolean(R.styleable.ColorPicker_colorpicker_showAlpha, true);
 			showHex = a.getBoolean(R.styleable.ColorPicker_colorpicker_showHex, true);
+			showPreview = a.getBoolean(R.styleable.ColorPicker_colorpicker_showPreview, true);
 		}
 		else {
 			selectNoneButtonText = null;
 			noneSelectedSummaryText = null;
 			showAlpha = true;
 			showHex = true;
+			showPreview = true;
 		}
 	}
 

--- a/colorpicker/src/main/res/values/attrs.xml
+++ b/colorpicker/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="colorpicker_noneSelectedSummaryText" format="string" />
         <attr name="colorpicker_showAlpha" format="boolean"/>
         <attr name="colorpicker_showHex" format="boolean"/>
+        <attr name="colorpicker_showPreview" format="boolean"/>
     </declare-styleable>
 
 </resources>

--- a/demo_app/src/main/res/layout/view_demo.xml
+++ b/demo_app/src/main/res/layout/view_demo.xml
@@ -11,6 +11,7 @@
         android:layout_height="match_parent"
         app:colorpicker_showAlpha="true"
         app:colorpicker_showHex="true"
+        app:colorpicker_showPreview="true"
         />
 
 </FrameLayout>


### PR DESCRIPTION
Hi Martin,
I really like your color picker and would like to use it for two little projects that I am currently working on.  However, the color picker would fit much better into my apps without the swatchView.
That is why I created this pull request that hopefully implements the complete functionality + readme documentation to hide the swatchView. 

I hope this functionality is fine for you.
-- Julian