### PR TITLE
Remove padding of color picker layout

### DIFF
--- a/colorpicker/src/main/res/layout-land/picker.xml
+++ b/colorpicker/src/main/res/layout-land/picker.xml
@@ -21,7 +21,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:padding="@dimen/margin"
     android:layout_gravity="center"
     >
 

--- a/colorpicker/src/main/res/layout/picker.xml
+++ b/colorpicker/src/main/res/layout/picker.xml
@@ -21,7 +21,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/margin"
     android:layout_gravity="center"
     >
 


### PR DESCRIPTION
Hello again,
I ran into the problem that the complete color picker has a padding of 16dp that must be considered when aligning other views with the color picker.

Therefor, I thought about removing the padding. Thus, the users of this library could decide for themselves about the margin.

Hope you like this modification.
--Julian